### PR TITLE
Use separate exports for ES and CommonJS modules

### DIFF
--- a/dist/wrapper.mjs
+++ b/dist/wrapper.mjs
@@ -1,0 +1,3 @@
+import cjsModule from './wavefile.js';
+
+export const WaveFile = cjsModule.WaveFile;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "main": "./dist/wavefile.js",
   "module": "./index.js",
+  "exports": {
+    "import": "./dist/wrapper.mjs",
+    "require": "./dist/wavefile.js"
+  },
   "types": "./index.d.ts",
   "bin": "./bin/wavefile.js",
   "engines": {


### PR DESCRIPTION
Following the approach recommended in the Node.js documentation:

https://nodejs.org/api/packages.html#approach-1-use-an-es-module-wrapper
